### PR TITLE
PKGBUILD: makefile does not support multithread

### DIFF
--- a/dists/PKGBUILD
+++ b/dists/PKGBUILD
@@ -40,10 +40,10 @@ build() {
   cd I-Nex
   ./configure --prefix=/usr
   cd ..
-  make
+  make -j1
 }
  
 package() {
   cd $pkgname
-  make install DESTDIR="$pkgdir"
+  make -j1 install DESTDIR="$pkgdir"
 }


### PR DESCRIPTION
```
[fademind@manjaro i-nex]$ makepkg -src    
==> Making package: i-nex 7.6.0-2 (śro, 4 sty 2017, 18:39:36 CET)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Updating I-Nex git repo...
Fetching origin
==> Validating source files with md5sums...
    I-Nex ... Skipped
==> Extracting sources...
  -> Creating working copy of I-Nex git repo...
Cloning into 'I-Nex'...
done.
Switched to a new branch 'makepkg'
==> Starting prepare()...
configure.ac:4: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.ac:4: http://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
configure.ac:4: installing './install-sh'
configure.ac:4: installing './missing'
==> Starting build()...
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking for gambas3 binaries... Ok
checking for gambas3 components path... Ok
checking for gb.image component... Ok
checking for gb.qt5 component... Ok
checking for gb.form component... Ok
checking for gb.desktop.x11 component... Ok
checking for gb.desktop component... Ok
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
Build I-Nex...
make -C I-Nex
make[1]: Entering directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/I-Nex'
Compiling i-nex project...
OK
make[1]: Leaving directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/I-Nex'
Build JSON...
make -C JSON
make[1]: Entering directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/JSON'
Compile i-nex-edid ✔
gcc -o i-nex-edid i-nex-edid.c -g -Wall -O2
i-nex-edid.c: In function 'detailed_block':
i-nex-edid.c:194:2: warning: 'width' may be used uninitialized in this function [-Wmaybe-uninitialized]
  printf("    %dx%d @ ( %s%s%s%s%s) Hz (%s%s preferred)\n", width, height,
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   fifty ? "50 " : "",
   ~~~~~~~~~~~~~~~~~~~
   sixty ? "60 " : "",
   ~~~~~~~~~~~~~~~~~~~
   seventyfive ? "75 " : "",
   ~~~~~~~~~~~~~~~~~~~~~~~~~
   eightyfive ? "85 " : "",
   ~~~~~~~~~~~~~~~~~~~~~~~~
   reduced ? "60RB " : "",
   ~~~~~~~~~~~~~~~~~~~~~~~
   names[(x[2] & 0x60) >> 5],
   ~~~~~~~~~~~~~~~~~~~~~~~~~~
   (((x[2] & 0x60) == 0x20) && reduced) ? "RB" : "");
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
i-nex-edid.c:155:9: note: 'width' was declared here
     int width, height;
         ^~~~~
i-nex-edid.c: In function 'main':
i-nex-edid.c:2045:26: warning: 'conformant_extension' may be used uninitialized in this function [-Wmaybe-uninitialized]
  nonconformant_extension += parse_extension(x);
                          ^~
i-nex-edid.c:110:5: warning: 'v' may be used uninitialized in this function [-Wmaybe-uninitialized]
     printf("%s%s: %s (%d)\n", prefix, field->name, v->description, val);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
i-nex-edid.c:95:19: note: 'v' was declared here
     struct value *v;
                   ^
make[1]: Leaving directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/JSON'
==> Entering fakeroot environment...
==> Starting package()...
Install pixmaps...
make -C pixmaps install
make[1]: Entering directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/pixmaps'
mkdir -p /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/pixmaps
install -m 644 i-nex.png /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/pixmaps/
install -m 644 i-nex-16.png /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/pixmaps/
install -m 644 i-nex-32.png /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/pixmaps/
install -m 644 i-nex-128.png /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/pixmaps/
make[1]: Leaving directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/pixmaps'
Create nedded dirs...
mkdir -p /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/applications
install -m 0755 debian/i-nex.desktop /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/applications/
install -m 0755 debian/i-nex-library.desktop /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/applications/
Install manpages...
make -C manpages install
make[1]: Entering directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/manpages'
Installing Man pages 1...
mkdir -p "/home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/man/man1/"
install -Dm644 i-nex.1 i-nex-edid.1 i-nex.gambas.1 "/home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/man/man1/"
Compress Man pages 1...
gzip -9 "/home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/man/man1/i-nex-edid.1"
gzip -9 "/home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/man/man1/i-nex.1"
gzip -9 "/home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/man/man1/i-nex.gambas.1"
make[1]: Leaving directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/manpages'
Installing Changelogs...
mkdir -p /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/doc/i-nex
install -Dm644 Changelog.md /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/share/doc/i-nex
Install JSON...
make -C JSON install
make[1]: Entering directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/JSON'
chmod +x i-nex-edid
test -d /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/bin || mkdir /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/bin
install -m 0755 i-nex-edid /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/bin
make[1]: Leaving directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/JSON'
Install I-Nex...
make -C I-Nex install
make[1]: Entering directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/I-Nex'
make[2]: Entering directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/I-Nex'
Installing i-nex.gambas file in /usr/bin...
make[2]: Nothing to be done for 'install-data-am'.
make[2]: Leaving directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/I-Nex'
make[1]: Leaving directory '/home/fademind/GitHub/packages-community/i-nex/src/I-Nex/I-Nex'
install -Dm 600 i2c_smbus.rules /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/lib/udev/rules.d/i2c_smbus.rules
ln -s /usr/bin/i-nex.gambas /home/fademind/GitHub/packages-community/i-nex/pkg/i-nex/usr/bin/i-nex
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issue...
==> Creating package "i-nex"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: i-nex 7.6.0-2 (śro, 4 sty 2017, 18:39:45 CET)
==> Cleaning up...
[fademind@manjaro i-nex]$ 
```